### PR TITLE
Fix git to pull from private repo

### DIFF
--- a/git.go
+++ b/git.go
@@ -56,7 +56,7 @@ func (g *GitClient) command(name string, arg ...string) *exec.Cmd {
 	cmd.Stderr = g.Output
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env,
-		"X_OAUTH_BASIC_TOKEN="+g.AccessToken,
+		"X_ACCESS_TOKEN="+os.Getenv("GH_APP_TOKEN"),
 		"GIT_ASKPASS=/usr/local/bin/askpass.sh")
 	return cmd
 }
@@ -75,7 +75,7 @@ func (g *GitClient) Init(branch string) error {
 	if err := g.command("git", "config", "user.email", "concourse@local").Run(); err != nil {
 		return fmt.Errorf("failed to configure git email: %s", err)
 	}
-	if err := g.command("git", "config", "url.https://x-oauth-basic@github.com/.insteadOf", "git@github.com:").Run(); err != nil {
+	if err := g.command("git", "config", "url.https://x-access-token@github.com/.insteadOf", "git@github.com:").Run(); err != nil {
 		return fmt.Errorf("failed to configure github url: %s", err)
 	}
 	if err := g.command("git", "config", "url.https://.insteadOf", "git://").Run(); err != nil {
@@ -232,6 +232,6 @@ func (g *GitClient) Endpoint(uri string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse commit url: %s", err)
 	}
-	endpoint.User = url.UserPassword("x-oauth-basic", g.AccessToken)
+	endpoint.User = url.UserPassword("x-access-token", os.Getenv("GH_APP_TOKEN"))
 	return endpoint.String(), nil
 }

--- a/git.go
+++ b/git.go
@@ -36,17 +36,19 @@ func NewGitClient(source *Source, dir string, output io.Writer) (*GitClient, err
 		os.Setenv("GIT_LFS_SKIP_SMUDGE", "true")
 	}
 	return &GitClient{
-		AccessToken: source.AccessToken,
-		Directory:   dir,
-		Output:      output,
+		AccessToken:  source.AccessToken,
+		Directory:    dir,
+		UseGitHubApp: source.UseGitHubApp,
+		Output:       output,
 	}, nil
 }
 
 // GitClient ...
 type GitClient struct {
-	AccessToken string
-	Directory   string
-	Output      io.Writer
+	AccessToken  string
+	Directory    string
+	UseGitHubApp bool
+	Output       io.Writer
 }
 
 func (g *GitClient) command(name string, arg ...string) *exec.Cmd {
@@ -55,9 +57,15 @@ func (g *GitClient) command(name string, arg ...string) *exec.Cmd {
 	cmd.Stdout = g.Output
 	cmd.Stderr = g.Output
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env,
-		"X_ACCESS_TOKEN="+os.Getenv("GH_APP_TOKEN"),
-		"GIT_ASKPASS=/usr/local/bin/askpass.sh")
+	if g.UseGitHubApp {
+		cmd.Env = append(cmd.Env,
+			"X_ACCESS_TOKEN="+os.Getenv("GH_APP_TOKEN"),
+			"GIT_ASKPASS=/usr/local/bin/askpass.sh")
+	} else {
+		cmd.Env = append(cmd.Env,
+			"X_ACCESS_TOKEN="+g.AccessToken,
+			"GIT_ASKPASS=/usr/local/bin/askpass.sh")
+	}
 	return cmd
 }
 
@@ -75,8 +83,14 @@ func (g *GitClient) Init(branch string) error {
 	if err := g.command("git", "config", "user.email", "concourse@local").Run(); err != nil {
 		return fmt.Errorf("failed to configure git email: %s", err)
 	}
-	if err := g.command("git", "config", "url.https://x-access-token@github.com/.insteadOf", "git@github.com:").Run(); err != nil {
-		return fmt.Errorf("failed to configure github url: %s", err)
+	if g.UseGitHubApp {
+		if err := g.command("git", "config", "url.https://x-access-token@github.com/.insteadOf", "git@github.com:").Run(); err != nil {
+			return fmt.Errorf("failed to configure github url: %s", err)
+		}
+	} else {
+		if err := g.command("git", "config", "url.https://x-oauth-basic@github.com/.insteadOf", "git@github.com:").Run(); err != nil {
+			return fmt.Errorf("failed to configure github url: %s", err)
+		}
 	}
 	if err := g.command("git", "config", "url.https://.insteadOf", "git://").Run(); err != nil {
 		return fmt.Errorf("failed to configure github url: %s", err)
@@ -232,6 +246,10 @@ func (g *GitClient) Endpoint(uri string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse commit url: %s", err)
 	}
-	endpoint.User = url.UserPassword("x-access-token", os.Getenv("GH_APP_TOKEN"))
+	if g.UseGitHubApp {
+		endpoint.User = url.UserPassword("x-access-token", os.Getenv("GH_APP_TOKEN"))
+	} else {
+		endpoint.User = url.UserPassword("x-oauth-basic", g.AccessToken)
+	}
 	return endpoint.String(), nil
 }

--- a/github.go
+++ b/github.go
@@ -65,7 +65,7 @@ func NewGithubClient(s *Source) (*GithubClient, error) {
 		var ghAppInstallationTransport *ghinstallation.Transport
 		if s.PrivateKey != "" {
 			ghAppInstallationTransport, err = ghinstallation.New(transport, s.ApplicationID, s.InstallationID, []byte(s.PrivateKey))
-			getGhAppToken,_ := ghAppInstallationTransport.Token(context.TODO())
+			getGhAppToken, _ := ghAppInstallationTransport.Token(context.TODO())
 			os.Setenv("GH_APP_TOKEN", getGhAppToken)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate application installation access token using private key: %s", err)

--- a/github.go
+++ b/github.go
@@ -65,6 +65,8 @@ func NewGithubClient(s *Source) (*GithubClient, error) {
 		var ghAppInstallationTransport *ghinstallation.Transport
 		if s.PrivateKey != "" {
 			ghAppInstallationTransport, err = ghinstallation.New(transport, s.ApplicationID, s.InstallationID, []byte(s.PrivateKey))
+			getGhAppToken,_ := ghAppInstallationTransport.Token(context.TODO())
+			os.Setenv("GH_APP_TOKEN", getGhAppToken)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate application installation access token using private key: %s", err)
 			}

--- a/models_test.go
+++ b/models_test.go
@@ -8,7 +8,6 @@ import (
 	resource "github.com/telia-oss/github-pr-resource"
 )
 
-
 var key = `-----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEA0BUezcR7uycgZsfVLlAf4jXP7uFpVh4geSTY39RvYrAll0yh
 q7uiQypP2hjQJ1eQXZvkAZx0v9lBYJmX7e0HiJckBr8+/O2kARL+GTCJDJZECpjy
@@ -87,10 +86,10 @@ func TestSource(t *testing.T) {
 		{
 			description: "requires an application_id and installation_id GitHub App configuration values",
 			source: resource.Source{
-				Repository:     "test/test",
-				UseGitHubApp:   true,
-				PrivateKey:     key,
-				ApplicationID:  123456,
+				Repository:    "test/test",
+				UseGitHubApp:  true,
+				PrivateKey:    key,
+				ApplicationID: 123456,
 			},
 			wantErr: "application_id and installation_id must be set if using GitHub App authentication",
 		},

--- a/scripts/askpass.sh
+++ b/scripts/askpass.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec echo "$X_OAUTH_BASIC_TOKEN"
 exec echo "$X_ACCESS_TOKEN"

--- a/scripts/askpass.sh
+++ b/scripts/askpass.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec echo "$X_OAUTH_BASIC_TOKEN"
+exec echo "$X_ACCESS_TOKEN"


### PR DESCRIPTION
Ran into an issue where Concourse was unable to pull from a private repo. 

```
Initialized empty Git repository in /tmp/build/get/.git/
Switched to a new branch 'main'
2024/01/04 21:48:31 get failed: pull failed: /usr/bin/git pull origin main
```

The purpose of this PR is to grab the JWT that is generated from `github.go` and export it as an environment variable where  git (from the `git.go` file) can be invoked. Condition has been added where it can use oauth or github app authentication.

Below is the code that grabs the JWT and export it as an env var.
```
getGhAppToken, _ := ghAppInstallationTransport.Token(context.TODO())
os.Setenv("GH_APP_TOKEN", getGhAppToken)
```